### PR TITLE
regex small fix

### DIFF
--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -5,7 +5,7 @@ var util = require('./util');
 
 var batCommand = 'pmset -g batt';
 
-var batteryStatRegex = /^ -InternalBattery-(\d)+\s+(\d+)%;.*?((?:(?:not )|(?:dis))?charging)/;
+var batteryStatRegex = /^ -InternalBattery-(\d)+\s+(\d+)%;.*?((?:(?:not )|(?:dis))?charg(?:ing|ed))/;
 
 /**
  * Callback used by the getChargeStatus function.


### PR DESCRIPTION
I'm currently using battery-status in Atom from @cmd-johnson and noticed that when the battery is fully charged, the package cannot properly fetch the status. The output shows something like

```
 -InternalBattery-0     99%; charged;
```

I modified the regex for a quick fix, just hope it works. Not really a regex master here, so maybe it's not the best way to do it.
