### PR TITLE
Added battery remaining time (macOS)

### DIFF
--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -5,7 +5,7 @@ var util = require('./util');
 
 var batCommand = 'pmset -g batt';
 
-var batteryStatRegex = /^ -InternalBattery-(\d)+\s+(?:\(id=\d+\))\s+(\d+)%;.*?((?:(?:not )|(?:dis))?charg(?:ing|ed))/;
+var batteryStatRegex = /^ -InternalBattery-(\d)+\s+(?:\(id=\d+\))\s+(\d+)%;.*?((?:(?:not )|(?:dis))?charg(?:ing|ed));.*?(?:(\d+:\d+)|(?:\(.*\)))/;
 
 /**
  * Callback used by the getChargeStatus function.
@@ -15,6 +15,7 @@ var batteryStatRegex = /^ -InternalBattery-(\d)+\s+(?:\(id=\d+\))\s+(\d+)%;.*?((
  * @param batteryStats.powerLevel   {Number} Battery charge in percent
  * @param batteryStats.chargeStatus {String} Battery status (either charging,
  *                                           discharging, full, or unknown)
+ * @param batteryStats.remaining    {String} Battery time remaining
  */
 /**
  * Checks the charge in percent, as well as the power status for all installed
@@ -42,9 +43,11 @@ module.exports.getChargeStatus = function(informationCollectedCb) {
       // var batteryId = match[1]; // we don't need this at the moment
       var powerLevel = parseInt(match[2], 10);
       var chargeStatus = util.validateChargeStatus(match[3]);
+      var remaining = match[4];
       batInfo.push({
         powerLevel: powerLevel,
-        chargeStatus: chargeStatus
+        chargeStatus: chargeStatus,
+        remaining: remaining
       });
     });
     informationCollectedCb(batInfo);


### PR DESCRIPTION
Extracts the remaining time (charge or discharge) from pmset, in an hh:mm format string (ex.: "1:54"). Undefined if no estimation is available.